### PR TITLE
Added check for important to view partial

### DIFF
--- a/src/views/message.blade.php
+++ b/src/views/message.blade.php
@@ -2,9 +2,10 @@
     @if (Session::has('flash_notification.overlay'))
         @include('flash::modal', ['modalClass' => 'flash-modal', 'title' => Session::get('flash_notification.title'), 'body' => Session::get('flash_notification.message')])
     @else
-        <div class="alert alert-{{ Session::get('flash_notification.level') }}">
-            <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
-
+        <div class="alert alert-{{ Session::get('flash_notification.level') }} {{ Session::has('flash_notification.important') ? 'alert-important' : null }}">
+            @if (Session::has('flash_notification.important'))
+                <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+            @endif
             {{ Session::get('flash_notification.message') }}
         </div>
     @endif


### PR DESCRIPTION
After following the tutorial on @laracasts I noticed the view partials in the package did not account for 'flash_notification.important' being flashed to the session from the important method.

This is my first ever pull request so I hope it was appropriate!

Thanks,
James 