### PR TITLE
Share flash_notification in views

### DIFF
--- a/src/Laracasts/Flash/ShareFlashNotificationFromSession.php
+++ b/src/Laracasts/Flash/ShareFlashNotificationFromSession.php
@@ -1,0 +1,41 @@
+<?php namespace Laracasts\Flash;
+
+
+use Closure;
+use Illuminate\Contracts\Routing\Middleware;
+use Illuminate\Contracts\View\Factory as ViewFactory;
+
+class ShareFlashNotificationFromSession implements Middleware {
+
+    /**
+     * The view factory implementation.
+     *
+     * @var \Illuminate\Contracts\View\Factory
+     */
+    protected $view;
+
+
+    /**
+     * @param \Illuminate\Contracts\View\Factory $view
+     */
+    function __construct(ViewFactory $view)
+    {
+        $this->view = $view;
+    }
+
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @param  \Closure $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $this->view->share(
+            'flash_notification', $request->session()->get('flash_notification'));
+
+        return $next($request);
+    }
+}

--- a/src/views/message.blade.php
+++ b/src/views/message.blade.php
@@ -1,11 +1,11 @@
-@if (Session::has('flash_notification.message'))
-    @if (Session::has('flash_notification.overlay'))
-        @include('flash::modal', ['modalClass' => 'flash-modal', 'title' => Session::get('flash_notification.title'), 'body' => Session::get('flash_notification.message')])
+@if ($flash_notification)
+    @if ($flash_notification['overlay'])
+        @include('flash::modal', ['modalClass' => 'flash-modal', 'title' => $flash_notification['title'], 'body' => $flash_notification['message']])
     @else
-        <div class="alert alert-{{ Session::get('flash_notification.level') }}">
+        <div class="alert alert-{{ $flash_notification['level'] }}">
             <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
 
-            {{ Session::get('flash_notification.message') }}
+            {{ $flash_notification['message'] }}
         </div>
     @endif
 @endif


### PR DESCRIPTION
I thought it would be better to use a simple variable inside views instead of utilizing `Session` facade.

**It seems the `\Laracasts\Flash\FlashServiceProvider` is just for laravel 5, so there was no way to share the variable for laravel 4.**