### PR TITLE
Update message.blade.php

### DIFF
--- a/src/views/message.blade.php
+++ b/src/views/message.blade.php
@@ -5,7 +5,7 @@
         <div class="alert alert-{{ Session::get('flash_notification.level') }}">
             <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
 
-            {{ Session::get('flash_notification.message') }}
+            {!! Session::get('flash_notification.message') !!}
         </div>
     @endif
 @endif


### PR DESCRIPTION
If I say Session::message("<b>Success!</b> Your payment when through great.") now it will show the success in bold, and not escape the html.