### PR TITLE
add ability to use unescaped text in message.body

### DIFF
--- a/src/Laracasts/Flash/FlashNotifier.php
+++ b/src/Laracasts/Flash/FlashNotifier.php
@@ -24,6 +24,7 @@ class FlashNotifier
      * Flash an information message.
      *
      * @param string $message
+     * @return $this
      */
     public function info($message)
     {
@@ -111,6 +112,18 @@ class FlashNotifier
     public function important()
     {
         $this->session->flash('flash_notification.important', true);
+
+        return $this;
+    }
+
+    /**
+     * Do not escaped flash body.
+     *
+     * @return $this
+     */
+    public function unescaped()
+    {
+        $this->session->flash('flash_notification.unescaped', true);
 
         return $this;
     }

--- a/src/views/message.blade.php
+++ b/src/views/message.blade.php
@@ -5,7 +5,11 @@
         <div class="alert alert-{{ Session::get('flash_notification.level') }}">
             <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
 
-            {{ Session::get('flash_notification.message') }}
+            @if (Session::get('flash_notification.unescaped'))
+                {!! Session::get('flash_notification.message') !!}
+            @else
+                {{ Session::get('flash_notification.message') }}
+            @endif
         </div>
     @endif
 @endif

--- a/src/views/modal.blade.php
+++ b/src/views/modal.blade.php
@@ -8,7 +8,13 @@
             </div>
 
             <div class="modal-body">
-                <p>{{ $body }}</p>
+                <p>
+                    @if (Session::get('flash_notification.unescaped'))
+                        {!! $body !!}
+                    @else
+                        {{ $body }}
+                    @endif
+                </p>
             </div>
 
             <div class="modal-footer">

--- a/tests/FlashTest.php
+++ b/tests/FlashTest.php
@@ -86,4 +86,15 @@ class FlashTest extends PHPUnit_Framework_TestCase {
         $this->flash->overlay('Overlay Message');
 	}
 
+	/** @test */
+	public function it_displays_unescaped_flash_notifications()
+	{
+        $this->session->shouldReceive('flash')->with('flash_notification.message', 'Unescaped <i>Message</i>');
+        $this->session->shouldReceive('flash')->with('flash_notification.title', 'Notice');
+        $this->session->shouldReceive('flash')->with('flash_notification.level', 'info');
+        $this->session->shouldReceive('flash')->with('flash_notification.unescaped', true);
+
+        $this->flash->unescaped()->message('Unescaped <i>Message</i>');
+	}
+
 }


### PR DESCRIPTION
Just adds an `flash()->unescaped()->...` function to be able to render HTML in flash message body.

I see this is kind of requested feature (#28, #29), so I hope my realization of this can be pulled into main repo... thanks!

upd. added test