### PR TITLE
Update to latest Bootstrap CSS & JS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -100,7 +100,7 @@ Because flash messages and overlays are so common, if you want, you may use (or 
 <head>
     <meta charset="UTF-8">
     <title>Document</title>
-    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
 </head>
 <body>
 
@@ -111,7 +111,7 @@ Because flash messages and overlays are so common, if you want, you may use (or 
 </div>
 
 <script src="//code.jquery.com/jquery.js"></script>
-<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
 
 <!-- This is only necessary if you do Flash::overlay('...') -->
 <script>
@@ -155,4 +155,3 @@ return Redirect::home();
 ![https://dl.dropboxusercontent.com/u/774859/GitHub-Repos/flash/overlay.png](https://dl.dropboxusercontent.com/u/774859/GitHub-Repos/flash/overlay.png)
 
 > [Learn exactly how to build this very package on Laracasts!](https://laracasts.com/lessons/flexible-flash-messages)
-


### PR DESCRIPTION
Updating CDN links to latest version, 3.3.5 from 3.2.0.

Experienced some odd effects with overlays in some instances, where model-overlay would appear on top of the modal. I think this was more often occurring on the 3.3.0 branch of Bootstrap, but none the less, good to be updated.