### PR TITLE
Removing not needed arguments

### DIFF
--- a/src/Laracasts/Flash/FlashNotifier.php
+++ b/src/Laracasts/Flash/FlashNotifier.php
@@ -80,7 +80,7 @@ class FlashNotifier
      */
     public function overlay($message, $title = 'Notice')
     {
-        $this->message($message, 'info', $title);
+        $this->message($message, $title);
 
         $this->session->flash('flash_notification.overlay', true);
         $this->session->flash('flash_notification.title', $title);

--- a/src/Laracasts/Flash/FlashNotifier.php
+++ b/src/Laracasts/Flash/FlashNotifier.php
@@ -80,7 +80,7 @@ class FlashNotifier
      */
     public function overlay($message, $title = 'Notice')
     {
-        $this->message($message, $title);
+        $this->message($message);
 
         $this->session->flash('flash_notification.overlay', true);
         $this->session->flash('flash_notification.title', $title);


### PR DESCRIPTION
Fixing arguments so modal function would not display warning.