### PR TITLE
make compatible with Laravel 5.2

### DIFF
--- a/src/Laracasts/Flash/FlashServiceProvider.php
+++ b/src/Laracasts/Flash/FlashServiceProvider.php
@@ -24,7 +24,7 @@ class FlashServiceProvider extends ServiceProvider
             'Laracasts\Flash\LaravelSessionStore'
         );
 
-        $this->app->bindShared('flash', function () {
+        $this->app->singleton('flash', function () {
             return $this->app->make('Laracasts\Flash\FlashNotifier');
         });
     }


### PR DESCRIPTION
In Laravel 5.2 the service container's `bindShared` method has been deprecated in favor of the `singleton` method.