### PR TITLE
Clear flash notification session after display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.phar
 composer.lock
 .DS_Store
+/.idea

--- a/src/Laracasts/Flash/LaravelSessionStore.php
+++ b/src/Laracasts/Flash/LaravelSessionStore.php
@@ -29,6 +29,7 @@ class LaravelSessionStore implements SessionStore
      */
     public function flash($name, $data)
     {
-        $this->session->flash($name, $data);
+        if (! $this->session->has($name))
+            $this->session->flash($name, $data);
     }
 }

--- a/src/views/message.blade.php
+++ b/src/views/message.blade.php
@@ -1,16 +1,16 @@
-@if (session()->has('flash_notification.message'))
-    @if (session()->has('flash_notification.overlay'))
+@if (!empty($flash_notification = session()->pull('flash_notification', '')))
+    @if (!empty($flash_notification['overlay']))
         @include('flash::modal', [
             'modalClass' => 'flash-modal',
-            'title'      => session('flash_notification.title'),
-            'body'       => session('flash_notification.message')
+            'title'      => $flash_notification['title'],
+            'body'       => $flash_notification['message']
         ])
     @else
         <div class="alert
-                    alert-{{ session('flash_notification.level') }}
-                    {{ session()->has('flash_notification.important') ? 'alert-important' : '' }}"
+                    alert-{{ $flash_notification['level'] }}
+                    {{ !empty($flash_notification['important']) ? 'alert-important' : '' }}"
         >
-            @if(session()->has('flash_notification.important'))
+            @if(!empty($flash_notification['important']))
                 <button type="button"
                         class="close"
                         data-dismiss="alert"
@@ -18,7 +18,7 @@
                 >&times;</button>
             @endif
 
-            {!! session('flash_notification.message') !!}
+            {!! $flash_notification['message'] !!}
         </div>
     @endif
 @endif


### PR DESCRIPTION
This PR adds functionality to automatically clear flash notification session after it is rendered. Sometimes the session keeps getting displayed, if the user presses a back button.