### PR TITLE
doc update readme with specific vendor publish

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -94,7 +94,7 @@ Because flash messages and overlays are so common, if you want, you may use (or 
 If you need to modify the flash message partials, you can run:
 
 ```bash
-php artisan vendor:publish
+php artisan vendor:publish --provider="Laracasts\Flash\FlashServiceProvider"
 ```
 
 The two package views will now be located in the `app/views/packages/laracasts/flash/` directory.


### PR DESCRIPTION
running `php artisan vendor:publish` without arguments pulls in all
the vendor packages as an override leaving the project stale as updates
come in for the rest of the packages.