### PR TITLE
Include role as per Bootstrap implementation

### DIFF
--- a/src/views/message.blade.php
+++ b/src/views/message.blade.php
@@ -9,6 +9,7 @@
         <div class="alert
                     alert-{{ $message['level'] }}
                     {{ $message['important'] ? 'alert-important' : '' }}"
+                    role="alert"
         >
             @if ($message['important'])
                 <button type="button"


### PR DESCRIPTION
The role attribute appears in both v3 and v4 of Bootstrap. This commit adds the missing role attribute.

http://getbootstrap.com/components/#alerts
https://v4-alpha.getbootstrap.com/components/alerts/#examples