### PR TITLE
Readme: add type info.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,7 @@ You may also do:
 - `flash('Message')->success()`: Set the flash theme to "success".
 - `flash('Message')->error()`: Set the flash theme to "danger".
 - `flash('Message')->warning()`: Set the flash theme to "warning".
+- `flash('Message')->info()`: Set the flash theme to "warning".
 - `flash('Message')->overlay()`: Render the message as an overlay.
 - `flash()->overlay('Modal Message', 'Modal Title')`: Display a modal overlay with a title.
 - `flash('Message')->important()`: Add a close button to the flash message.


### PR DESCRIPTION
The info type is missing from the docs. Adding this for convenience.