### PR TITLE
Added withFlash macro to RedirectResponse

### DIFF
--- a/src/Laracasts/Flash/FlashServiceProvider.php
+++ b/src/Laracasts/Flash/FlashServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Laracasts\Flash;
 
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\ServiceProvider;
 
 class FlashServiceProvider extends ServiceProvider
@@ -27,6 +28,12 @@ class FlashServiceProvider extends ServiceProvider
 
         $this->app->singleton('flash', function () {
             return $this->app->make('Laracasts\Flash\FlashNotifier');
+        });
+        
+        RedirectResponse::macro('withFlash', function ($message, $level = 'info') {
+            app('flash')->message($message, $level);
+            
+            return $this;
         });
     }
 


### PR DESCRIPTION
Instead of writing
```php
flash('Some message', 'danger');

return redirect()->route('index');
```
we can now write
```php
return redirect()->route('index')->withFlash('Some message', 'danger');
```