### PR TITLE
Add div.flash-message wrapper for CSS targeting

### DIFF
--- a/src/views/message.blade.php
+++ b/src/views/message.blade.php
@@ -19,7 +19,7 @@
                 >&times;</button>
             @endif
 
-            {!! $message['message'] !!}
+            <div class="flash-message">{!! $message['message'] !!}</div>
         </div>
     @endif
 @endforeach


### PR DESCRIPTION
This will allow improved CSS/UI targeting for the message body.

For example `.flash-message { white-space: pre }` can allow text-formatted messages to appear exactly as intended.

Something like this won't work with `.alert { white-space: pre }` since the `alert` markup contains lots of new lines and spaces used for formatting.