### PR TITLE
Fixed Bootstrap 4 display bug.

### DIFF
--- a/src/views/modal.blade.php
+++ b/src/views/modal.blade.php
@@ -2,9 +2,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-
                 <h4 class="modal-title">{{ $title }}</h4>
+                
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
             </div>
 
             <div class="modal-body">


### PR DESCRIPTION
Change the order of the modal title and the close button, due to the elements being displayed incorrect with Bootstrap 4.