### PR TITLE
Make FlashNotifier class macroable

### DIFF
--- a/src/Laracasts/Flash/FlashNotifier.php
+++ b/src/Laracasts/Flash/FlashNotifier.php
@@ -2,8 +2,12 @@
 
 namespace Laracasts\Flash;
 
+use Illuminate\Support\Traits\Macroable;
+
 class FlashNotifier
 {
+    use Macroable;
+
     /**
      * The session store.
      *

--- a/tests/FlashTest.php
+++ b/tests/FlashTest.php
@@ -158,6 +158,16 @@ class FlashTest extends TestCase
         $this->assertCount(0, $this->flash->messages);
     }
 
+    /** @test */
+    function it_is_macroable()
+    {
+        $this->flash->macro('passthru', function ($message) {
+            return $message;
+        });
+
+        $this->assertEquals('Macroable Message', $this->flash->passthru('Macroable Message'));
+    }
+
     protected function assertSessionIsFlashed($times = 1)
     {
         $this->session


### PR DESCRIPTION
Allow userland to define custom flash message behavior, such as a JavaScript-enabled toast notification:

```php
FlashNotifier::macro('toast', function ($message, $level = 'info', $title = null, $time = 5, $sticky = 0)
{
    $this->message($message, $level);

    $this->session->flash('flash_notification.toast', true);
    $this->session->flash('flash_notification.title', $title);
    $this->session->flash('flash_notification.time', $time);
    $this->session->flash('flash_notification.sticky', $sticky);

    return $this;
});
```

```php
FlashNotifier::macro('hasToast' function () {
    return (bool) $this->session->get('flash_notification.toast');
});
```

```php
FlashNotifier::macro('toastJs', function ($message = '', $title = 'Info', $type = 'info', $time = 5, $sticky = 0) {
    if ($this->hasToast()) {
        return vsprintf('$.gritter.add({title: %s, text: %s, class_name: "color " + %s, time: %s, sticky: %s});',
            array_map(function ($key) {
                return json_encode($this->session->get($key));
            }, [
                'flash_notification.message',
                'flash_notification.title',
                'flash_notification.level',
                'flash_notification.time',
                'flash_notification.sticky',
            ])
        );
    }
});
```

```html
flash()->toast('Your post has been unpublished.', 'success');

// then in the Blade view:

<script>
    {!! flash()->toastJs() !!}
</script>
```