### PR TITLE
Removed 'or' Blade operator in favor of '??' for Laravel 5.7 support

### DIFF
--- a/src/views/modal.blade.php
+++ b/src/views/modal.blade.php
@@ -1,4 +1,4 @@
-<div id="flash-overlay-modal" class="modal fade {{ $modalClass or '' }}">
+<div id="flash-overlay-modal" class="modal fade {{ $modalClass ?? '' }}">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">


### PR DESCRIPTION
According to the [official upgrade guide](https://laravel.com/docs/5.7/upgrade): `The Blade "or" operator has been removed in favor of PHP's built-in ?? "null coalesce" operator, which has the same purpose and functionality.`