### PR TITLE
Fixes modal class name

### DIFF
--- a/src/views/modal.blade.php
+++ b/src/views/modal.blade.php
@@ -1,4 +1,4 @@
-<div id="flash-overlay-modal" class="modal fade {{ $modalClass or '' }}">
+<div id="flash-overlay-modal" class="modal fade {{ $modalClass }}">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">


### PR DESCRIPTION
Dispalying 1 instead of "flash-modal" or user defined $modalClass in the view. 