### PR TITLE
[bugfix] Implement Laravel 5.7's dropping of `or` in blade templates

### DIFF
--- a/src/views/modal.blade.php
+++ b/src/views/modal.blade.php
@@ -1,4 +1,4 @@
-<div id="flash-overlay-modal" class="modal fade {{ $modalClass or '' }}">
+<div id="flash-overlay-modal" class="modal fade {{ isset($modalClass) ? $modalClass : '' }}">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">


### PR DESCRIPTION
- See https://laravel.com/docs/5.7/upgrade
- When the `or` is evaluated now - it returns a boolean value
- The resulting class is `"modal fade 1"`
- Use `isset()` instead of null coalescence in order to maintain PHP `>=5.4.0` compatibility.