### PR TITLE
Update illuminate/support version restraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "~5.0|^6.0"
+        "illuminate/support": ">=5.0.0"
     },
     "require-dev": {
         "mockery/mockery": "dev-master",


### PR DESCRIPTION
Changed it so that anything above 5.0.0 is acceptable. The likelihood of a Laravel version bringing a breaking change for this package is extremely low and this saves adding a new version constraint every 6 months to follow semver.