### PR TITLE
Update FlashNotifier.php

### DIFF
--- a/src/Laracasts/Flash/FlashNotifier.php
+++ b/src/Laracasts/Flash/FlashNotifier.php
@@ -159,9 +159,16 @@ class FlashNotifier
      */
     protected function flash()
     {
-        $this->session->flash('flash_notification', $this->messages);
+      $notifications = session('flash_notification', collect());
+      if( $this->messages->count() > 0 ) {
+          foreach( $this->messages as $message ) {
+              $notifications->push($message);
+          }
+      }
 
-        return $this;
+      $this->session->flash('flash_notification', $notifications->unique());
+
+      return $this;
     }
 }
 


### PR DESCRIPTION
To be able to display flash messages accross multiple page requests which add additional flash messages the flash_notification session key needs to be preserved.

This solves #128 for me. With the existing pull request I got duplicate messages.