### PR TITLE
Add 'danger' method to match bootstrap class

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,8 +32,10 @@ public function store()
 You may also do:
 
 - `flash('Message')->success()`: Set the flash theme to "success".
-- `flash('Message')->error()`: Set the flash theme to "danger".
+- `flash('Message')->danger()`: Set the flash theme to "danger".
 - `flash('Message')->warning()`: Set the flash theme to "warning".
+- `flash('Message')->info()`: Set the flash theme to "info".
+- `flash('Message')->error()`: Set the flash theme to "danger".
 - `flash('Message')->overlay()`: Render the message as an overlay.
 - `flash()->overlay('Modal Message', 'Modal Title')`: Display a modal overlay with a title.
 - `flash('Message')->important()`: Add a close button to the flash message.

--- a/src/Laracasts/Flash/FlashNotifier.php
+++ b/src/Laracasts/Flash/FlashNotifier.php
@@ -67,6 +67,17 @@ class FlashNotifier
     }
 
     /**
+     * Flash a danger message.
+     *
+     * @param  string|null $message
+     * @return $this
+     */
+    public function danger($message = null)
+    {
+        return $this->message($message, 'danger');
+    }
+
+    /**
      * Flash a warning message.
      *
      * @param  string|null $message


### PR DESCRIPTION
There are four "standard" [bootstrap alert classes](https://getbootstrap.com/docs/4.4/components/alerts/#link-color) in addition to the other less standard alerts. The four "proper" alert types are success, info, warning and danger. The `alert-danger` class does not match the `->error()` method name like the other methods do. This leads to confusing behavior.

```
flash($message)->info();      => class="alert alert-info"
flash($message)->success();   => class="alert alert-success"
flash($message)->warning();   => class="alert alert-warning"
flash($message)->danger();   Does not exist
flash($message)->error();      => class="alert alert-danger"
```

The original `->error()` method remains unchanged for backwards compatibility.