### PR TITLE
Add PHP 8.1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,12 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": "^8.0|^8.1",
         "illuminate/support": "~5.0|^6.0|^7.0|^8.0"
     },
     "require-dev": {
         "mockery/mockery": "dev-master",
-        "phpunit/phpunit": "^6.1"
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-0": {

--- a/src/Laracasts/Flash/Message.php
+++ b/src/Laracasts/Flash/Message.php
@@ -73,7 +73,7 @@ class Message implements \ArrayAccess
      * @param  mixed $offset
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->$offset);
     }
@@ -84,7 +84,7 @@ class Message implements \ArrayAccess
      * @param  mixed $offset
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->$offset;
     }
@@ -95,7 +95,7 @@ class Message implements \ArrayAccess
      * @param  mixed $offset
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, $value): void
     {
         $this->$offset = $value;
     }
@@ -106,7 +106,7 @@ class Message implements \ArrayAccess
      * @param  mixed $offset
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         //
     }


### PR DESCRIPTION
this fixed E_DEPRECATION on PHP 8.1:
```
Return type of Laracasts\Flash\Message::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/vendor/laracasts/flash/src/Laracasts/Flash/Message.php line 76 in  ...
```

Unlike https://github.com/laracasts/flash/pull/169, it uses typehints and raises minimal supported version of PHP to 8.0